### PR TITLE
Directory service 6

### DIFF
--- a/DirectoryProject.sln
+++ b/DirectoryProject.sln
@@ -24,6 +24,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{81DDED9D-158B-E303-5F62-77A2896D2A5A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DirectoryService.Tests", "tests\DirectoryService.Tests\DirectoryService.Tests.csproj", "{481C7366-6D69-4CF2-A93B-3EECA1F1B342}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared.Tests", "tests\Shared.Tests\Shared.Tests.csproj", "{51938D2C-6593-4ACA-9595-164D503457A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +54,14 @@ Global
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{481C7366-6D69-4CF2-A93B-3EECA1F1B342}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{481C7366-6D69-4CF2-A93B-3EECA1F1B342}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{481C7366-6D69-4CF2-A93B-3EECA1F1B342}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{481C7366-6D69-4CF2-A93B-3EECA1F1B342}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51938D2C-6593-4ACA-9595-164D503457A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51938D2C-6593-4ACA-9595-164D503457A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51938D2C-6593-4ACA-9595-164D503457A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51938D2C-6593-4ACA-9595-164D503457A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,6 +72,8 @@ Global
 		{8040A341-7C36-4884-979C-1831938CF814} = {1F5D8F6F-04DB-4A6F-97A6-F467F695DCE5}
 		{2A3614E9-F9E8-46C6-9EF9-4F52FF29DD0C} = {1F5D8F6F-04DB-4A6F-97A6-F467F695DCE5}
 		{A75CAD39-37FC-4546-A370-2DE57234AB8A} = {1F5D8F6F-04DB-4A6F-97A6-F467F695DCE5}
+		{481C7366-6D69-4CF2-A93B-3EECA1F1B342} = {F3D65D26-2596-4290-AD6E-07BF78F6E4A3}
+		{51938D2C-6593-4ACA-9595-164D503457A8} = {F3D65D26-2596-4290-AD6E-07BF78F6E4A3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FA164B78-DC63-496E-A526-CEA658D2956E}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/SoftDeleteDepartment/SoftDeleteDepartmentCommand.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/SoftDeleteDepartment/SoftDeleteDepartmentCommand.cs
@@ -1,0 +1,6 @@
+﻿using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+
+namespace DirectoryProject.DirectoryService.Application.DepartmentHandlers.SoftDeleteDepartment;
+
+public record SoftDeleteDepartmentCommand(
+    Guid Id) : ICommand;

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/SoftDeleteDepartment/SoftDeleteDepartmentCommandValidator.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/SoftDeleteDepartment/SoftDeleteDepartmentCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using DirectoryProject.DirectoryService.Application.Shared.Validation;
+using DirectoryProject.DirectoryService.Domain.Shared;
+using FluentValidation;
+
+namespace DirectoryProject.DirectoryService.Application.DepartmentHandlers.SoftDeleteDepartment;
+
+public class SoftDeleteDepartmentCommandValidator : AbstractValidator<SoftDeleteDepartmentCommand>
+{
+    public SoftDeleteDepartmentCommandValidator()
+    {
+        RuleFor(c => c.Id)
+            .NotEmpty()
+            .Must(d => d != Guid.Empty)
+            .WithError(ErrorHelper.General.ValueIsNullOrEmpty("Id"));
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/SoftDeleteDepartment/SoftDeleteDepartmentHandler.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/SoftDeleteDepartment/SoftDeleteDepartmentHandler.cs
@@ -1,0 +1,102 @@
+﻿using DirectoryProject.DirectoryService.Application.Interfaces;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.Shared;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+
+namespace DirectoryProject.DirectoryService.Application.DepartmentHandlers.SoftDeleteDepartment;
+
+public class SoftDeleteDepartmentHandler
+    : ICommandHandler<SoftDeleteDepartmentCommand>
+{
+    private readonly AbstractValidator<SoftDeleteDepartmentCommand> _validator;
+    private readonly ILogger<SoftDeleteDepartmentHandler> _logger;
+    private readonly IDepartmentRepository _departmentRepository;
+    private readonly ILocationRepository _locationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SoftDeleteDepartmentHandler(
+        AbstractValidator<SoftDeleteDepartmentCommand> validator,
+        ILogger<SoftDeleteDepartmentHandler> logger,
+        IDepartmentRepository departmentRepository,
+        ILocationRepository locationRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _validator = validator;
+        _logger = logger;
+        _departmentRepository = departmentRepository;
+        _locationRepository = locationRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<UnitResult> HandleAsync(
+        SoftDeleteDepartmentCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        // command validation
+        var validatorResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validatorResult.IsValid)
+        {
+            return validatorResult.Errors
+                .Select(e => Error.Deserialize(e.ErrorMessage))
+                .ToList();
+        }
+
+        // check if entity exists
+        var entityResult = await _departmentRepository.GetByIdAsync(
+            id: Id<Department>.Create(command.Id),
+            cancellationToken: cancellationToken);
+        if (entityResult.IsFailure)
+            return entityResult.Errors;
+
+        var entity = entityResult.Value;
+
+        // check if entity has children
+        var childrenResult = await _departmentRepository.GetChildrenByPathAsync(
+            entity.Path,
+            cancellationToken);
+        if (childrenResult.IsFailure) return childrenResult.Errors;
+        if (childrenResult.Value.Any())
+        {
+            return ErrorHelper.Database.DeleteFailedConflict(
+                $"Failed to delete entity with path {entity.Path}, because it has active children");
+        }
+
+        // check if entity has active locations
+        var locationsResult = await _locationRepository.GetLocationsForDepartmentAsync(
+            entity.Id,
+            cancellationToken);
+        if (locationsResult.IsFailure) return locationsResult.Errors;
+        if (locationsResult.Value.Any())
+        {
+            return ErrorHelper.Database.DeleteFailedConflict(
+                $"Department with id {entity.Id.Value} still has active locations");
+        }
+
+        var transaction = await _unitOfWork.BeginTransactionAsync(cancellationToken);
+
+        if (entity.Parent is not null)
+        {
+            entity.Parent.DecreaseChildrenCount();
+            var parentUpdateResult = await _departmentRepository.UpdateAsync(
+                entity.Parent,
+                cancellationToken);
+            if (parentUpdateResult.IsFailure)
+                return parentUpdateResult.Errors;
+        }
+
+        entity.Deactivate();
+        var entityUpdateResult = await _departmentRepository.UpdateAsync(
+                entity,
+                cancellationToken);
+        if (entityUpdateResult.IsFailure)
+        {
+            transaction.Rollback();
+            return entityUpdateResult.Errors;
+        }
+
+        return UnitResult.Success();
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/UpdateDepartment/UpdateDepartmentHandler.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/DepartmentHandlers/UpdateDepartment/UpdateDepartmentHandler.cs
@@ -118,18 +118,6 @@ public class UpdateDepartmentHandler
         var oldPath = entity.Path;
         var oldLocations = entity.DepartmentLocations;
 
-        // update entity
-        if (isNameChanged || isParentChanged)
-        {
-            entity.Update(
-                name: isNameChanged ? newName : entity.Name,
-                parentId: isParentChanged ? newParent?.Id : entity.ParentId,
-                path: updatedPathResult.Value);
-        }
-
-        if (areLocationsChanged)
-            entity.UpdateLocations(command.LocationIds.Select(Id<Location>.Create));
-
         // update old parent if not null
         if (isParentChanged && oldParent is not null)
         {
@@ -154,7 +142,18 @@ public class UpdateDepartmentHandler
             }
         }
 
-        // update entity in database
+        // update entity
+        if (isNameChanged || isParentChanged)
+        {
+            entity.Update(
+                name: isNameChanged ? newName : entity.Name,
+                parentId: isParentChanged ? newParent?.Id : entity.ParentId,
+                path: updatedPathResult.Value);
+        }
+
+        if (areLocationsChanged)
+            entity.UpdateLocations(command.LocationIds.Select(Id<Location>.Create));
+
         if (isNameChanged || isParentChanged || areLocationsChanged)
         {
             var entityUpdateResult = await _departmentRepository.UpdateAsync(

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IDepartmentRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IDepartmentRepository.cs
@@ -25,6 +25,10 @@ public interface IDepartmentRepository
         LTree path,
         CancellationToken cancellationToken = default);
 
+    Task<Result<IEnumerable<Department>>> GetChildrenByPathAsync(
+        LTree path,
+        CancellationToken cancellationToken = default);
+
     Task<UnitResult> UpdateChildrenPathAsync(
         LTree oldPath,
         LTree newPath,

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IDepartmentRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IDepartmentRepository.cs
@@ -21,6 +21,10 @@ public interface IDepartmentRepository
         Id<Department> id,
         CancellationToken cancellationToken = default);
 
+    Task<Result<IEnumerable<Department>>> GetDepartmentsForLocationAsync(
+        Id<Location> id,
+        CancellationToken cancellationToken = default);
+
     Task<Result<IEnumerable<Department>>> GetFlatTreeAsync(
         LTree path,
         CancellationToken cancellationToken = default);
@@ -29,7 +33,7 @@ public interface IDepartmentRepository
         LTree path,
         CancellationToken cancellationToken = default);
 
-    Task<UnitResult> UpdateChildrenPathAsync(
+    Task<Result<int>> UpdateChildrenPathAsync(
         LTree oldPath,
         LTree newPath,
         CancellationToken cancellationToken = default);

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/ILocationInterface.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/ILocationInterface.cs
@@ -15,6 +15,10 @@ public interface ILocationRepository
         LocationName name,
         CancellationToken cancellationToken = default);
 
+    Task<Result<IEnumerable<Location>>> GetLocationsForDepartmentAsync(
+        Id<Department> id,
+        CancellationToken cancellationToken = default);
+
     Task<Result<Location>> CreateAsync(
         Location entity,
         CancellationToken cancellationToken = default);

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/SoftDeleteLocation/SoftDeleteLocationCommand.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/SoftDeleteLocation/SoftDeleteLocationCommand.cs
@@ -1,0 +1,6 @@
+﻿using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+
+namespace DirectoryProject.DirectoryService.Application.LocationHandlers.SoftDeleteLocation;
+
+public record SoftDeleteLocationCommand(
+    Guid Id) : ICommand;

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/SoftDeleteLocation/SoftDeleteLocationCommandValidator.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/SoftDeleteLocation/SoftDeleteLocationCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using DirectoryProject.DirectoryService.Application.Shared.Validation;
+using DirectoryProject.DirectoryService.Domain.Shared;
+using FluentValidation;
+
+namespace DirectoryProject.DirectoryService.Application.LocationHandlers.SoftDeleteLocation;
+
+public class SoftDeleteLocationCommandValidator : AbstractValidator<SoftDeleteLocationCommand>
+{
+    public SoftDeleteLocationCommandValidator()
+    {
+        RuleFor(c => c.Id)
+            .NotEmpty()
+            .Must(d => d != Guid.Empty)
+            .WithError(ErrorHelper.General.ValueIsNullOrEmpty("Id"));
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/SoftDeleteLocation/SoftDeleteLocationHandler.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/SoftDeleteLocation/SoftDeleteLocationHandler.cs
@@ -1,0 +1,78 @@
+﻿using DirectoryProject.DirectoryService.Application.Interfaces;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.Shared;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+
+namespace DirectoryProject.DirectoryService.Application.LocationHandlers.SoftDeleteLocation;
+
+public class SoftDeleteLocationHandler
+    : ICommandHandler<SoftDeleteLocationCommand>
+{
+    private readonly AbstractValidator<SoftDeleteLocationCommand> _validator;
+    private readonly ILogger<SoftDeleteLocationHandler> _logger;
+    private readonly ILocationRepository _locationRepository;
+    private readonly IDepartmentRepository _departmentRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SoftDeleteLocationHandler(
+        AbstractValidator<SoftDeleteLocationCommand> validator,
+        ILogger<SoftDeleteLocationHandler> logger,
+        ILocationRepository locationRepository,
+        IDepartmentRepository departmentRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _validator = validator;
+        _logger = logger;
+        _locationRepository = locationRepository;
+        _departmentRepository = departmentRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<UnitResult> HandleAsync(
+        SoftDeleteLocationCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        // command validation
+        var validatorResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validatorResult.IsValid)
+        {
+            return validatorResult.Errors
+                .Select(e => Error.Deserialize(e.ErrorMessage))
+                .ToList();
+        }
+
+        // check if entity exists
+        var entityResult = await _locationRepository.GetByIdAsync(
+            id: Id<Location>.Create(command.Id),
+            cancellationToken: cancellationToken);
+        if (entityResult.IsFailure)
+            return entityResult.Errors;
+
+        var entity = entityResult.Value;
+
+        var departmentsResult = await _departmentRepository.GetDepartmentsForLocationAsync(
+            entity.Id,
+            cancellationToken);
+        if (departmentsResult.IsFailure)
+            return departmentsResult.Errors;
+        if (departmentsResult.Value.Any())
+        {
+            return ErrorHelper.Database.DeleteFailedConflict(
+                $"Failed to delete Location with id {entity.Id.Value}. It still has active departments");
+        }
+
+        entity.Deactivate();
+        var entityUpdateResult = await _locationRepository.UpdateAsync(
+            entity,
+            cancellationToken);
+        if (entityUpdateResult.IsFailure)
+            return entityUpdateResult.Errors;
+
+        _logger.LogInformation("Location with id {0} was deactivated", entity.Id);
+
+        return UnitResult.Success();
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/UpdateLocation/UpdateLocationHandler.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/UpdateLocation/UpdateLocationHandler.cs
@@ -71,6 +71,8 @@ public class UpdateLocationHandler
         if (updateResult.IsFailure)
             return updateResult.Errors;
 
+        _logger.LogInformation("Location with id {id} was updated", entity.Id);
+
         return LocationDTO.FromDomainEntity(entity);
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/SoftDeletePosition/SoftDeletePositionCommand.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/SoftDeletePosition/SoftDeletePositionCommand.cs
@@ -1,0 +1,6 @@
+﻿using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+
+namespace DirectoryProject.DirectoryService.Application.PositionHandlers.SoftDeletePosition;
+
+public record SoftDeletePositionCommand(
+    Guid Id) : ICommand;

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/SoftDeletePosition/SoftDeletePositionCommandValidator.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/SoftDeletePosition/SoftDeletePositionCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using DirectoryProject.DirectoryService.Application.Shared.Validation;
+using DirectoryProject.DirectoryService.Domain.Shared;
+using FluentValidation;
+
+namespace DirectoryProject.DirectoryService.Application.PositionHandlers.SoftDeletePosition;
+
+public class SoftDeletePositionCommandValidator : AbstractValidator<SoftDeletePositionCommand>
+{
+    public SoftDeletePositionCommandValidator()
+    {
+        RuleFor(c => c.Id)
+            .NotEmpty()
+            .Must(d => d != Guid.Empty)
+            .WithError(ErrorHelper.General.ValueIsNullOrEmpty("Id"));
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/SoftDeletePosition/SoftDeletePositionHandler.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/SoftDeletePosition/SoftDeletePositionHandler.cs
@@ -1,0 +1,70 @@
+﻿using DirectoryProject.DirectoryService.Application.Interfaces;
+using DirectoryProject.DirectoryService.Application.LocationHandlers.SoftDeleteLocation;
+using DirectoryProject.DirectoryService.Application.Shared.DTOs;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.Shared;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DirectoryProject.DirectoryService.Application.PositionHandlers.SoftDeletePosition;
+
+public class SoftDeletePositionHandler
+    : ICommandHandler<SoftDeletePositionCommand>
+{
+    private readonly AbstractValidator<SoftDeletePositionCommand> _validator;
+    private readonly ILogger<SoftDeletePositionHandler> _logger;
+    private readonly IPositionRepository _positionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SoftDeletePositionHandler(
+        AbstractValidator<SoftDeletePositionCommand> validator,
+        ILogger<SoftDeletePositionHandler> logger,
+        IPositionRepository positionRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _validator = validator;
+        _logger = logger;
+        _positionRepository = positionRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<UnitResult> HandleAsync(
+        SoftDeletePositionCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        // command validation
+        var validatorResult = await _validator.ValidateAsync(command, cancellationToken);
+        if (!validatorResult.IsValid)
+        {
+            return validatorResult.Errors
+                .Select(e => Error.Deserialize(e.ErrorMessage))
+                .ToList();
+        }
+
+        // check if entity exists
+        var entityResult = await _positionRepository.GetByIdAsync(
+            id: Id<Position>.Create(command.Id),
+            cancellationToken: cancellationToken);
+        if (entityResult.IsFailure)
+            return entityResult.Errors;
+
+        var entity = entityResult.Value;
+
+        entity.Deactivate();
+
+        var updateResult = await _positionRepository.UpdateAsync(entity, cancellationToken);
+        if (updateResult.IsFailure)
+            return updateResult.Errors;
+
+        _logger.LogInformation("Position with id {id} was deactivated", entity.Id);
+
+        return UnitResult.Success();
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/UpdatePosition/UpdatePositionHandler.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/UpdatePosition/UpdatePositionHandler.cs
@@ -67,6 +67,8 @@ public class UpdatePositionHandler
         if (updateResult.IsFailure)
             return updateResult.Errors;
 
+        _logger.LogInformation("Position with id {id} was updated", entity.Id);
+
         return PositionDTO.FromDomainEntity(entity);
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Department.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Department.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using DirectoryProject.DirectoryService.Domain.DepartmentValueObjects;
 using DirectoryProject.DirectoryService.Domain.Shared;
@@ -77,6 +76,20 @@ public class Department
     {
         if (ChildrenCount > 0)
             ChildrenCount--;
+        return this;
+    }
+
+    public Department Deactivate()
+    {
+        IsActive = false;
+        UpdatedAt = DateTime.UtcNow;
+        return this;
+    }
+
+    public Department Activate()
+    {
+        IsActive = true;
+        UpdatedAt = DateTime.UtcNow;
         return this;
     }
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Location.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Location.cs
@@ -10,7 +10,7 @@ public class Location
     public LocationName Name { get; private set; }
     public LocationAddress Address { get; private set; }
     public IANATimeZone TimeZone { get; private set; }
-    public bool IsActive { get; } = true;
+    public bool IsActive { get; private set; } = true;
     public DateTime CreatedAt { get; }
     public DateTime UpdatedAt { get; private set; }
 
@@ -42,6 +42,20 @@ public class Location
         TimeZone = timeZone;
         UpdatedAt = DateTime.UtcNow;
 
+        return this;
+    }
+
+    public Location Deactivate()
+    {
+        IsActive = false;
+        UpdatedAt = DateTime.UtcNow;
+        return this;
+    }
+
+    public Location Activate()
+    {
+        IsActive = true;
+        UpdatedAt = DateTime.UtcNow;
         return this;
     }
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Position.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Position.cs
@@ -37,6 +37,20 @@ public class Position
         return this;
     }
 
+    public Position Deactivate()
+    {
+        IsActive = false;
+        UpdatedAt = DateTime.UtcNow;
+        return this;
+    }
+
+    public Position Activate()
+    {
+        IsActive = true;
+        UpdatedAt = DateTime.UtcNow;
+        return this;
+    }
+
     // EF Core
     private Position() { }
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Shared/ErrorHelper.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Shared/ErrorHelper.cs
@@ -46,6 +46,16 @@ public static class ErrorHelper
         }
     }
 
+    public static class Database
+    {
+        public static Error DeleteFailedConflict(string message)
+        {
+            return Error.Conflict(
+                "delete.failed",
+                message);
+        }
+    }
+
     public static class Tree
     {
         public static Error CycleInTree(Guid entityId)

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Configurations/DepartmentConfiguration.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Configurations/DepartmentConfiguration.cs
@@ -49,7 +49,6 @@ public class DepartmentConfiguration : IEntityTypeConfiguration<Department>
             .HasColumnName("path");
 
         builder.HasIndex(d => d.Path)
-            .IsUnique()
             .HasMethod("gist");  // to use ltree's operators
 
         builder.Property(d => d.Depth)

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/DepartmentRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/DepartmentRepository.cs
@@ -53,7 +53,7 @@ public class DepartmentRepository : IDepartmentRepository
         return result;
     }
 
-    public async Task<UnitResult> UpdateChildrenPathAsync(
+    public async Task<Result<int>> UpdateChildrenPathAsync(
         LTree oldPath,
         LTree newPath,
         CancellationToken cancellationToken = default)
@@ -67,7 +67,7 @@ public class DepartmentRepository : IDepartmentRepository
             // UPDATE item
             // SET path = NEW.path || subpath(path, nlevel(OLD.path))
             // WHERE path<@ OLD.path;
-            await _context.Departments
+            var changedCount = await _context.Departments
                 .Where(d => d.IsActive)
                 .Where(d => d.Path.IsDescendantOf(oldPath))
                 .Where(d => d.Path != newPath)
@@ -81,7 +81,7 @@ public class DepartmentRepository : IDepartmentRepository
                         d => d.Path.NLevel - 1 - oldDepth + newDepth),  // d.Path.NLevel - 1 won't work, because it will not be updated yet
                     cancellationToken);
 
-            return UnitResult.Success();
+            return changedCount;
         }
         catch (DbUpdateConcurrencyException)
         {

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/DepartmentRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/DepartmentRepository.cs
@@ -154,4 +154,17 @@ public class DepartmentRepository : IDepartmentRepository
             return ErrorHelper.Tree.ConcurrentUpdateFailed(entity.Id.Value);
         }
     }
+
+    public async Task<Result<IEnumerable<Department>>> GetDepartmentsForLocationAsync(
+        Id<Location> id,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await (
+            from d in _context.Departments
+            join dl in _context.DepartmentLocations on d.Id equals dl.DepartmentId
+            where dl.LocationId == id
+            select d).ToListAsync(cancellationToken);
+
+        return result;
+    }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/DepartmentRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/DepartmentRepository.cs
@@ -40,6 +40,19 @@ public class DepartmentRepository : IDepartmentRepository
         return result;
     }
 
+    public async Task<Result<IEnumerable<Department>>> GetChildrenByPathAsync(
+        LTree path,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _context.Departments
+            .Where(d => d.IsActive)
+            .Where(d => d.Path.IsDescendantOf(path))
+            .Where(d => d.Path != path)
+            .ToListAsync(cancellationToken);
+
+        return result;
+    }
+
     public async Task<UnitResult> UpdateChildrenPathAsync(
         LTree oldPath,
         LTree newPath,

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/LocationRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Database/Repositories/LocationRepository.cs
@@ -4,7 +4,6 @@ using DirectoryProject.DirectoryService.Domain.LocationValueObjects;
 using DirectoryProject.DirectoryService.Domain.Shared;
 using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
 using Microsoft.EntityFrameworkCore;
-using System.Linq;
 
 namespace DirectoryProject.DirectoryService.Infrastructure.Database.Repositories;
 
@@ -37,6 +36,19 @@ public class LocationRepository : ILocationRepository
             return ErrorHelper.General.NotFound(name.Value);
 
         return entity;
+    }
+
+    public async Task<Result<IEnumerable<Location>>> GetLocationsForDepartmentAsync(
+        Id<Department> id,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await (
+            from l in _context.Locations
+            join dl in _context.DepartmentLocations on l.Id equals dl.LocationId
+            where dl.DepartmentId == id
+            select l).ToListAsync(cancellationToken);
+
+        return result;
     }
 
     public async Task<Result<Location>> CreateAsync(

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250531105452_Directory_RemovedUniqueIndexForPath.Designer.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250531105452_Directory_RemovedUniqueIndexForPath.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using DirectoryProject.DirectoryService.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DirectoryProject.DirectoryService.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDBContext))]
-    partial class ApplicationDBContextModelSnapshot : ModelSnapshot
+    [Migration("20250531105452_Directory_RemovedUniqueIndexForPath")]
+    partial class Directory_RemovedUniqueIndexForPath
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250531105452_Directory_RemovedUniqueIndexForPath.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250531105452_Directory_RemovedUniqueIndexForPath.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DirectoryProject.DirectoryService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Directory_RemovedUniqueIndexForPath : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_departments_path",
+                schema: "diretory_service",
+                table: "departments");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_departments_path",
+                schema: "diretory_service",
+                table: "departments",
+                column: "path")
+                .Annotation("Npgsql:IndexMethod", "gist");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_departments_path",
+                schema: "diretory_service",
+                table: "departments");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_departments_path",
+                schema: "diretory_service",
+                table: "departments",
+                column: "path",
+                unique: true)
+                .Annotation("Npgsql:IndexMethod", "gist");
+        }
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Controllers/DepartmentsController.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Controllers/DepartmentsController.cs
@@ -1,4 +1,5 @@
 ﻿using DirectoryProject.DirectoryService.Application.DepartmentHandlers.CreateDepartment;
+using DirectoryProject.DirectoryService.Application.DepartmentHandlers.SoftDeleteDepartment;
 using DirectoryProject.DirectoryService.Application.DepartmentHandlers.UpdateDepartment;
 using DirectoryProject.DirectoryService.Application.Shared.DTOs;
 using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
@@ -50,10 +51,13 @@ public class DepartmentsController : ApplicationController
     }
 
     [HttpDelete("{id:guid}")]
-    public async Task<IActionResult> Delete()
+    public async Task<IActionResult> Delete(
+        [FromServices] ICommandHandler<SoftDeleteDepartmentCommand> handler,
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
     {
-        //soft-delete отдела
-        //    запрет, если есть активные потомки.
-        return Ok();
+        var command = new SoftDeleteDepartmentCommand(id);
+
+        return ToAPIResponse(await handler.HandleAsync(command, cancellationToken));
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Controllers/LocationsController.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Controllers/LocationsController.cs
@@ -1,4 +1,5 @@
 ﻿using DirectoryProject.DirectoryService.Application.LocationHandlers.CreateLocation;
+using DirectoryProject.DirectoryService.Application.LocationHandlers.SoftDeleteLocation;
 using DirectoryProject.DirectoryService.Application.LocationHandlers.UpdateLocation;
 using DirectoryProject.DirectoryService.Application.Shared.DTOs;
 using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
@@ -26,5 +27,16 @@ public class LocationsController : ApplicationController
         CancellationToken cancellationToken = default)
     {
         return ToAPIResponse(await handler.HandleAsync(request.ToCommand(id), cancellationToken));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(
+        [FromServices] ICommandHandler<SoftDeleteLocationCommand> handler,
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new SoftDeleteLocationCommand(id);
+
+        return ToAPIResponse(await handler.HandleAsync(command, cancellationToken));
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Controllers/PositionsController.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Controllers/PositionsController.cs
@@ -1,4 +1,5 @@
 ﻿using DirectoryProject.DirectoryService.Application.PositionHandlers.CreatePosition;
+using DirectoryProject.DirectoryService.Application.PositionHandlers.SoftDeletePosition;
 using DirectoryProject.DirectoryService.Application.PositionHandlers.UpdatePosition;
 using DirectoryProject.DirectoryService.Application.Shared.DTOs;
 using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
@@ -26,5 +27,16 @@ public class PositionsController : ApplicationController
         CancellationToken cancellationToken = default)
     {
         return ToAPIResponse(await handler.HandleAsync(request.ToCommand(id), cancellationToken));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(
+        [FromServices] ICommandHandler<SoftDeletePositionCommand> handler,
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new SoftDeletePositionCommand(id);
+
+        return ToAPIResponse(await handler.HandleAsync(command, cancellationToken));
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Program.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Program.cs
@@ -9,3 +9,5 @@ var app = builder.Build();
 await app.ConfigureAsync();
 
 app.Run();
+
+public partial class Program;  // to access Program class in test projects

--- a/tests/DirectoryService.Tests/DepartmentHandlers/CreateDepartmentHandlerTests.cs
+++ b/tests/DirectoryService.Tests/DepartmentHandlers/CreateDepartmentHandlerTests.cs
@@ -1,0 +1,91 @@
+﻿using DirectoryProject.DirectoryService.Application.DepartmentHandlers.CreateDepartment;
+using DirectoryProject.DirectoryService.Application.Shared.DTOs;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.DepartmentValueObjects;
+using DirectoryProject.DirectoryService.Domain.LocationValueObjects;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shared.Tests;
+
+namespace DirectoryService.Tests.DepartmentHandlers;
+
+public class CreateDepartmentHandlerTests : DirectoryServiceBaseHandlerTests
+{
+    private readonly ICommandHandler<CreateDepartmentCommand, DepartmentDTO> _sut;
+
+    public CreateDepartmentHandlerTests(TestWebFactory webFactory) : base(webFactory)
+    {
+        _sut = _scope.ServiceProvider
+            .GetRequiredService<ICommandHandler<CreateDepartmentCommand, DepartmentDTO>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_AddingDepartmentWithParent_ReturnSuccess()
+    {
+        // Arrange
+        var location = Location.Create(
+            id: Id<Location>.GenerateNew(),
+            name: LocationName.Create("Test Location").Value,
+            address: LocationAddress.Create("Moscow", "Lenina", "1").Value,
+            timeZone: IANATimeZone.Create("Europe/Moscow").Value,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Locations.Add(location);
+
+        var parentDepartment = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Test Parent").Value,
+            parent: null,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Departments.Add(parentDepartment);
+
+        var parentDepartmentLocation = new DepartmentLocation(
+            parentDepartment.Id,
+            location.Id);
+        _context.DepartmentLocations.Add(parentDepartmentLocation);
+
+        await _context.SaveChangesAsync();
+
+        var command = new CreateDepartmentCommand(
+            Name: "Test Department",
+            LocationIds: [location.Id.Value],
+            ParentId: parentDepartment.Id.Value);
+
+        var ct = new CancellationTokenSource().Token;
+
+        // Act
+        var result = await _sut.HandleAsync(command, ct);
+
+        // Assert
+        Assert.True(
+            result.IsSuccess,
+            result.IsSuccess ? string.Empty : result.Errors.First().Message);
+        Assert.True(result.Value is not null, "Result value is null");
+
+        // check if the entity is in the database
+        var testName = DepartmentName.Create(command.Name).Value;
+        var entity = await _context.Departments.FirstOrDefaultAsync(d => d.Name == testName);
+        Assert.True(entity is not null, "Entity from database is null");
+        Assert.True(entity.IsActive, "Entity is not active");
+        Assert.True(entity.ParentId is not null, "Entity's parent id is null");
+
+        var expectedPath = Department.CreatePath(testName, parentDepartment.Path).Value;
+        Assert.True(
+            entity.Path == expectedPath,
+            $"Entity's path is incorrect: expected {expectedPath}, got {entity.Path}");
+        var expectedDepth = Department.CalculateDepth(expectedPath);
+        Assert.True(
+            entity.Depth == expectedDepth,
+            $"Entity's depth is incorrect: expected {expectedDepth}, got {entity.Depth}");
+
+        var expectedLocationDepartments = await _context.DepartmentLocations
+            .Where(d => d.DepartmentId == entity.Id)
+            .ToListAsync();
+        Assert.True(
+            expectedLocationDepartments.Count != 0,
+            "DepartmentLocation was not created");
+
+        Assert.True(parentDepartment.ChildrenCount == 1, "Parent's children count is 0, expected 1");
+    }
+}

--- a/tests/DirectoryService.Tests/DepartmentHandlers/SoftDeleteDepartmentHandlerTests.cs
+++ b/tests/DirectoryService.Tests/DepartmentHandlers/SoftDeleteDepartmentHandlerTests.cs
@@ -1,0 +1,89 @@
+﻿using DirectoryProject.DirectoryService.Application.DepartmentHandlers.SoftDeleteDepartment;
+using DirectoryProject.DirectoryService.Application.DepartmentHandlers.UpdateDepartment;
+using DirectoryProject.DirectoryService.Application.Shared.DTOs;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.DepartmentValueObjects;
+using DirectoryProject.DirectoryService.Domain.LocationValueObjects;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shared.Tests;
+
+namespace DirectoryService.Tests.DepartmentHandlers;
+
+public class SoftDeleteDepartmentHandlerTests : DirectoryServiceBaseHandlerTests
+{
+    private readonly ICommandHandler<SoftDeleteDepartmentCommand> _sut;
+
+    public SoftDeleteDepartmentHandlerTests(TestWebFactory webFactory) : base(webFactory)
+    {
+        _sut = _scope.ServiceProvider
+            .GetRequiredService<ICommandHandler<SoftDeleteDepartmentCommand>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_DeletingDepartmentWithValidCommand_ReturnSuccess()
+    {
+        // Arrange
+        var location = Location.Create(
+            id: Id<Location>.GenerateNew(),
+            name: LocationName.Create("Moscow location").Value,
+            address: LocationAddress.Create("Moscow", "Lenina", "1").Value,
+            timeZone: IANATimeZone.Create("Europe/Moscow").Value,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Locations.Add(location);
+
+        var parent = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Parent test").Value,
+            parent: null,
+            createdAt: DateTime.UtcNow).Value;
+
+        var department = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Department test").Value,
+            parent: parent,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Departments.AddRange([parent, department]);
+
+        _context.DepartmentLocations.AddRange([
+            new DepartmentLocation(parent.Id, location.Id),
+            new DepartmentLocation(department.Id, location.Id),
+            ]);
+
+        await _context.SaveChangesAsync();
+
+        var command = new SoftDeleteDepartmentCommand(
+            Id: department.Id.Value);
+
+        var ct = new CancellationTokenSource().Token;
+
+        // Act
+        var result = await _sut.HandleAsync(command, ct);
+
+        // Assert
+        Assert.True(
+            result.IsSuccess,
+            result.IsSuccess ? string.Empty : result.Errors.First().Message);
+
+        // check if the entity is in the database but deactivated
+        var testId = Id<Department>.Create(command.Id);
+        var entity = await _context.Departments
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(d => d.Id == testId);
+        Assert.True(entity is not null, "Entity from database is null");
+        Assert.True(entity.IsActive == false, "Entity is active, expected otherwise");
+
+        var expectedLocationDepartments = await _context.DepartmentLocations
+            .Where(d => d.DepartmentId == entity.Id && d.LocationId == location.Id)
+            .ToListAsync();
+        Assert.True(
+            expectedLocationDepartments.Count != 0,
+            "DepartmentLocation was deleted, expected otherwise");
+
+        Assert.True(
+            parent.ChildrenCount == 0,
+            $"Parent's children count is incorrect: expected 0, got {parent.ChildrenCount}");
+    }
+}

--- a/tests/DirectoryService.Tests/DepartmentHandlers/UpdateDepartmentHandlerTests.cs
+++ b/tests/DirectoryService.Tests/DepartmentHandlers/UpdateDepartmentHandlerTests.cs
@@ -1,0 +1,117 @@
+﻿using DirectoryProject.DirectoryService.Application.DepartmentHandlers.UpdateDepartment;
+using DirectoryProject.DirectoryService.Application.Shared.DTOs;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.DepartmentValueObjects;
+using DirectoryProject.DirectoryService.Domain.LocationValueObjects;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shared.Tests;
+
+namespace DirectoryService.Tests.DepartmentHandlers;
+
+public class UpdateDepartmentHandlerTests : DirectoryServiceBaseHandlerTests
+{
+    private readonly ICommandHandler<UpdateDepartmentCommand, DepartmentDTO> _sut;
+
+    public UpdateDepartmentHandlerTests(TestWebFactory webFactory) : base(webFactory)
+    {
+        _sut = _scope.ServiceProvider
+            .GetRequiredService<ICommandHandler<UpdateDepartmentCommand, DepartmentDTO>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_UpdatingDepartmentWithValidCommand_ReturnSuccess()
+    {
+        // Arrange
+        var locationBeforeUpdate = Location.Create(
+            id: Id<Location>.GenerateNew(),
+            name: LocationName.Create("Moscow location").Value,
+            address: LocationAddress.Create("Moscow", "Lenina", "1").Value,
+            timeZone: IANATimeZone.Create("Europe/Moscow").Value,
+            createdAt: DateTime.UtcNow).Value;
+        var locationAfterUpdate = Location.Create(
+            id: Id<Location>.GenerateNew(),
+            name: LocationName.Create("Saint Petersburg Location").Value,
+            address: LocationAddress.Create("Saint Petersburg", "Lenina", "2").Value,
+            timeZone: IANATimeZone.Create("Europe/Moscow").Value,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Locations.AddRange([locationBeforeUpdate, locationAfterUpdate]);
+
+        var parentBeforeUpdate = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Parent Before Update").Value,
+            parent: null,
+            createdAt: DateTime.UtcNow).Value;
+        var parentAfterUpdate = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Parent After Update").Value,
+            parent: null,
+            createdAt: DateTime.UtcNow).Value;
+
+        var departmentBeforeUpdate = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Department Before Update").Value,
+            parent: parentBeforeUpdate,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Departments.AddRange([parentBeforeUpdate, parentAfterUpdate, departmentBeforeUpdate]);
+
+        _context.DepartmentLocations.AddRange([
+            new DepartmentLocation(parentBeforeUpdate.Id, locationBeforeUpdate.Id),
+            new DepartmentLocation(departmentBeforeUpdate.Id, locationBeforeUpdate.Id),
+            new DepartmentLocation(parentAfterUpdate.Id, locationAfterUpdate.Id),
+            ]);
+
+        await _context.SaveChangesAsync();
+
+        var command = new UpdateDepartmentCommand(
+            Id: departmentBeforeUpdate.Id.Value,
+            Name: "Department After Update",
+            LocationIds: [locationAfterUpdate.Id.Value],
+            ParentId: parentAfterUpdate.Id.Value);
+
+        var ct = new CancellationTokenSource().Token;
+
+        // Act
+        var result = await _sut.HandleAsync(command, ct);
+
+        // Assert
+        Assert.True(
+            result.IsSuccess,
+            result.IsSuccess ? string.Empty : result.Errors.First().Message);
+        Assert.True(result.Value is not null, "Result value is null");
+
+        // check if the entity is in the database
+        var testName = DepartmentName.Create(command.Name).Value;
+        var entity = await _context.Departments.FirstOrDefaultAsync(d => d.Name == testName);
+        Assert.True(entity is not null, "Entity from database is null");
+        Assert.True(entity.IsActive, "Entity is not active");
+        Assert.True(
+            entity.ParentId is not null,
+            $"Entity's parent changed to null, expected parent with id {parentAfterUpdate.Id.Value}");
+
+        var expectedPath = Department.CreatePath(testName, parentAfterUpdate.Path).Value;
+        Assert.True(
+            entity.Path == expectedPath,
+            $"Entity's path is incorrect: expected {expectedPath}, got {entity.Path}");
+        var expectedDepth = Department.CalculateDepth(expectedPath);
+        Assert.True(
+            entity.Depth == expectedDepth,
+            $"Entity's depth is incorrect: expected {expectedDepth}, got {entity.Depth}");
+
+        var expectedLocationDepartments = await _context.DepartmentLocations
+            .Where(d => d.DepartmentId == entity.Id && d.LocationId == locationAfterUpdate.Id)
+            .ToListAsync();
+        Assert.True(
+            expectedLocationDepartments.Count != 0,
+            "DepartmentLocation was not created");
+
+        Assert.True(
+            parentBeforeUpdate.ChildrenCount == 0,
+            $"Old parent's children count is incorrect: expected 0, got {parentBeforeUpdate.ChildrenCount}");
+        Assert.True(
+            parentAfterUpdate.ChildrenCount == 1,
+            $"New parent's children count is incorrect: expected 1, got {parentAfterUpdate.ChildrenCount}");
+    }
+}

--- a/tests/DirectoryService.Tests/DirectoryService.Tests.csproj
+++ b/tests/DirectoryService.Tests/DirectoryService.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared.Tests\Shared.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DirectoryService.Tests/DirectoryServiceBaseHandlerTests.cs
+++ b/tests/DirectoryService.Tests/DirectoryServiceBaseHandlerTests.cs
@@ -1,0 +1,21 @@
+﻿using DirectoryProject.DirectoryService.Infrastructure.Database;
+using Microsoft.Extensions.DependencyInjection;
+using Shared.Tests;
+
+namespace DirectoryService.Tests;
+
+public class DirectoryServiceBaseHandlerTests : BaseHandlerTests
+{
+    public DirectoryServiceBaseHandlerTests(TestWebFactory webFactory) : base(webFactory)
+    {
+        _context = _scope.ServiceProvider.GetRequiredService<ApplicationDBContext>();
+    }
+
+    protected readonly ApplicationDBContext _context;
+
+    public override async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        await base.DisposeAsync();
+    }
+}

--- a/tests/Shared.Tests/BaseHandlerTests.cs
+++ b/tests/Shared.Tests/BaseHandlerTests.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Shared.Tests;
+
+public abstract class BaseHandlerTests : IClassFixture<TestWebFactory>, IAsyncLifetime
+{
+    protected readonly TestWebFactory _webFactory;
+    protected readonly IServiceScope _scope;
+
+    public BaseHandlerTests(TestWebFactory webFactory)
+    {
+        _webFactory = webFactory;
+        _scope = _webFactory.Services.CreateScope();
+    }
+
+    public virtual async Task DisposeAsync()
+    {
+        await _webFactory.ResetDatabaseAsync();
+        _scope.Dispose();
+    }
+
+    public virtual async Task InitializeAsync() { }
+}

--- a/tests/Shared.Tests/IntegrationTestWebFactory.cs
+++ b/tests/Shared.Tests/IntegrationTestWebFactory.cs
@@ -1,0 +1,60 @@
+﻿using DirectoryProject.DirectoryService.Infrastructure.Database;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Shared.Tests;
+
+public class TestWebFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    protected string _connectionString = string.Empty;
+
+    private readonly PostgreSqlContainer _dbContainer = new PostgreSqlBuilder()
+        .WithImage("postgres")
+        .WithDatabase("directory_service_tests")
+        .WithUsername("postgresUser")
+        .WithPassword("postgresPassword")
+        .Build();
+
+    public async Task ResetDatabaseAsync()
+    {
+        using var scope = Services.CreateScope();
+
+        var accountContext =
+            scope.ServiceProvider.GetRequiredService<ApplicationDBContext>();
+
+        await accountContext.Database.EnsureDeletedAsync();
+
+        await accountContext.Database.EnsureCreatedAsync();
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _dbContainer.StartAsync();
+
+        _connectionString = _dbContainer.GetConnectionString();
+
+        await ResetDatabaseAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _dbContainer.StopAsync();
+        await _dbContainer.DisposeAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureTestServices(ReplaceServices);
+    }
+
+    protected virtual void ReplaceServices(IServiceCollection services)
+    {
+        services.RemoveAll<ApplicationDBContext>();
+        services.AddScoped(_ => new ApplicationDBContext(_connectionString));
+    }
+}

--- a/tests/Shared.Tests/Shared.Tests.csproj
+++ b/tests/Shared.Tests/Shared.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DirectoryService\DirectoryProject.DirectoryService.WebAPI\DirectoryProject.DirectoryService.WebAPI.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Добавил soft delete для Department, Location и Position.
Исходя из комментария в телеге ("Удаление нужно сделать только через soft delete. То есть можно сначала деактивировать подразделения, а потом деактивировать локации"), сделал возможность soft delete для Department, даже если у него есть активные локации.

Ещё начал делать интеграционные тесты. Пока сделал только для Department (как для самой сложной логики), когда сдам следующее задание, доделаю для всех фич.

Вопрос вот ещё есть, про тестирование обновления Department. Мы в нем пользуемся механизмом, предотвращающим одновременные обновления, чтобы целостность структуры дерева не нарушалась. А есть ли какой-то подход к тому, как это тестировать автоматически? Их время выполнения не детерминировано, значит просто отправить сначала один запрос, подождать условные 5мс и отправить второй - это не совсем правильно, может пройти тест, а может и не пройти