### PR TITLE
Directory service fixes

### DIFF
--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IDepartmentRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IDepartmentRepository.cs
@@ -22,12 +22,6 @@ public interface IDepartmentRepository
         Id<Department> id,
         CancellationToken cancellationToken = default);
 
-    Task<Result<(int TotalCount, IEnumerable<DepartmentTreeDTO> Values)>> GetRootsWithChildrenAsync(
-        int Page,
-        int PageSize,
-        int Prefetch,
-        CancellationToken cancellationToken = default);
-
     Task<Result<IEnumerable<Department>>> GetDepartmentsForLocationAsync(
         Id<Location> id,
         CancellationToken cancellationToken = default);
@@ -47,5 +41,9 @@ public interface IDepartmentRepository
 
     Task<UnitResult> IsPathUniqueAsync(
         LTree path,
+        CancellationToken cancellationToken = default);
+
+    Task<UnitResult> AreDepartmentsValidAsync(
+        IEnumerable<Id<Department>> departmentIds,
         CancellationToken cancellationToken = default);
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/ILocationInterface.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/ILocationInterface.cs
@@ -37,6 +37,10 @@ public interface ILocationRepository
         LocationName name,
         CancellationToken cancellationToken = default);
 
+    Task<UnitResult> IsAddressUniqueAsync(
+        LocationAddress address,
+        CancellationToken cancellationToken = default);
+
     Task<UnitResult> AreLocationsValidAsync(
         IEnumerable<Id<Location>> locationIds,
         CancellationToken cancellationToken = default);

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IPositionRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/Interfaces/IPositionRepository.cs
@@ -22,7 +22,8 @@ public interface IPositionRepository
 
     Task<Result<Position>> UpdateAsync(
         Position entity,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        IEnumerable<DepartmentPosition>? oldDepartmentPositions = null);
 
     Task<UnitResult> IsNameUniqueAsync(
         PositionName name,

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/CreateLocation/CreateLocationHandler.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/LocationHandlers/CreateLocation/CreateLocationHandler.cs
@@ -49,6 +49,9 @@ public class CreateLocationHandler
             command.Address.City,
             command.Address.Street,
             command.Address.HouseNumber).Value!;
+        var isAddressUnique = await _locationRepository.IsAddressUniqueAsync(address, cancellationToken);
+        if (isAddressUnique.IsFailure)
+            return isAddressUnique.Errors;
 
         var timeZone = IANATimeZone.Create(command.TimeZone).Value!;
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/CreatePosition/CreatePositionCommand.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/CreatePosition/CreatePositionCommand.cs
@@ -4,4 +4,5 @@ namespace DirectoryProject.DirectoryService.Application.PositionHandlers.CreateP
 
 public record CreatePositionCommand(
     string Name,
-    string Description) : ICommand;
+    string Description,
+    IEnumerable<Guid> DepartmentIds) : ICommand;

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/CreatePosition/CreatePositionCommandValidator.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/CreatePosition/CreatePositionCommandValidator.cs
@@ -16,7 +16,7 @@ public class CreatePositionCommandValidator : AbstractValidator<CreatePositionCo
             .MustBeValueObject(PositionDescription.Create);
 
         RuleFor(c => c.DepartmentIds)
-                .NotEmpty()
-                .WithError(ErrorHelper.General.ValueIsNullOrEmpty("DepartmentIds"));
+            .NotEmpty()
+            .WithError(ErrorHelper.General.ValueIsNullOrEmpty("DepartmentIds"));
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/CreatePosition/CreatePositionCommandValidator.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/CreatePosition/CreatePositionCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using DirectoryProject.DirectoryService.Application.Shared.Validation;
 using DirectoryProject.DirectoryService.Domain.PositionValueObjects;
+using DirectoryProject.DirectoryService.Domain.Shared;
 using FluentValidation;
 
 namespace DirectoryProject.DirectoryService.Application.PositionHandlers.CreatePosition;
@@ -13,5 +14,9 @@ public class CreatePositionCommandValidator : AbstractValidator<CreatePositionCo
 
         RuleFor(c => c.Description)
             .MustBeValueObject(PositionDescription.Create);
+
+        RuleFor(c => c.DepartmentIds)
+                .NotEmpty()
+                .WithError(ErrorHelper.General.ValueIsNullOrEmpty("DepartmentIds"));
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/UpdatePosition/UpdatePositionCommand.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/UpdatePosition/UpdatePositionCommand.cs
@@ -5,4 +5,5 @@ namespace DirectoryProject.DirectoryService.Application.PositionHandlers.UpdateP
 public record UpdatePositionCommand(
     Guid Id,
     string Name,
-    string Description) : ICommand;
+    string Description,
+    IEnumerable<Guid> DepartmentIds) : ICommand;

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/UpdatePosition/UpdatePositionCommandValidator.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Application/PositionHandlers/UpdatePosition/UpdatePositionCommandValidator.cs
@@ -18,5 +18,9 @@ public class UpdatePositionCommandValidator : AbstractValidator<UpdatePositionCo
 
         RuleFor(c => c.Description)
             .MustBeValueObject(PositionDescription.Create);
+
+        RuleFor(c => c.DepartmentIds)
+            .NotEmpty()
+            .WithError(ErrorHelper.General.ValueIsNullOrEmpty("DepartmentIds"));
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Department.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Department.cs
@@ -21,10 +21,10 @@ public class Department
     public DateTime UpdatedAt { get; private set; }
 
     private List<DepartmentLocation> _departmentLocations = [];
-    public IReadOnlyList<DepartmentLocation> DepartmentLocations => _departmentLocations.ToList();
+    public IReadOnlyList<DepartmentLocation> DepartmentLocations => _departmentLocations.AsReadOnly();
 
-    //private List<Department> _children = [];
-    //public IReadOnlyList<Department> Children => _children.ToList();
+    private List<DepartmentPosition> _departmentPositions = [];
+    public IReadOnlyList<DepartmentPosition> DepartmentPositions => _departmentPositions.AsReadOnly();
 
     public List<Department> Children { get; private set; }
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/DepartmentPosition.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/DepartmentPosition.cs
@@ -1,0 +1,47 @@
+﻿using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+
+namespace DirectoryProject.DirectoryService.Domain;
+
+public class DepartmentPosition : IComparable<DepartmentPosition>, IEquatable<DepartmentPosition>
+{
+    public Id<Department> DepartmentId { get; }
+    public Department Department { get; }
+    public Id<Position> PositionId { get; }
+    public Position Position { get; }
+
+    public DepartmentPosition(
+        Id<Department> departmentId,
+        Id<Position> positionId)
+    {
+        DepartmentId = departmentId;
+        PositionId = positionId;
+    }
+
+    // EF Core
+    private DepartmentPosition() {}
+
+    public int CompareTo(DepartmentPosition? other)
+    {
+        if (other == null)
+            return -1;
+
+        if (DepartmentId.CompareTo(other.DepartmentId) == 0 && PositionId.CompareTo(other.PositionId) == 0)
+            return 0;
+
+        return -1;
+    }
+
+    public bool Equals(DepartmentPosition? other)
+    {
+        if (other is null)
+            return false;
+        return DepartmentId.Equals(other.DepartmentId) && PositionId.Equals(other.PositionId);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is DepartmentPosition other)
+            return Equals(other);
+        return false;
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Location.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Location.cs
@@ -15,7 +15,7 @@ public class Location
     public DateTime UpdatedAt { get; private set; }
 
     private List<DepartmentLocation> _departmentLocations = [];
-    public IReadOnlyList<DepartmentLocation> DepartmentLocations => _departmentLocations.ToList();
+    public IReadOnlyList<DepartmentLocation> DepartmentLocations => _departmentLocations.AsReadOnly();
 
     public static Result<Location> Create(
         Id<Location> id,

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/LocationValueObjects/LocationAddress.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/LocationValueObjects/LocationAddress.cs
@@ -1,8 +1,9 @@
 ﻿using DirectoryProject.DirectoryService.Domain.Shared;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
 
 namespace DirectoryProject.DirectoryService.Domain.LocationValueObjects;
 
-public class LocationAddress : IComparable<LocationAddress>
+public class LocationAddress : IComparable<LocationAddress>, IEquatable<LocationAddress>
 {
     public const int CITY_MAX_LENGTH = 100;
     public const int STREET_MAX_LENGTH = 100;
@@ -35,6 +36,20 @@ public class LocationAddress : IComparable<LocationAddress>
         if (other is null) throw new ArgumentNullException(nameof(other));
 
         return City == other.City && Street == other.Street && HouseNumber == other.HouseNumber ? 0 : -1;
+    }
+
+    public bool Equals(LocationAddress? other)
+    {
+        if (other is null)
+            return false;
+        return City == other.City && Street == other.Street && HouseNumber == other.HouseNumber;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is LocationAddress other)
+            return Equals(other);
+        return false;
     }
 
     private LocationAddress(

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Position.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Position.cs
@@ -9,11 +9,12 @@ public class Position
     public Id<Position> Id { get; }
     public PositionName Name { get; private set; }
     public PositionDescription Description { get; private set; }
-
-
     public bool IsActive { get; private set; } = true;
     public DateTime CreatedAt { get; }
     public DateTime UpdatedAt { get; private set; }
+
+    private List<DepartmentPosition> _departmentPositions = [];
+    public IReadOnlyList<DepartmentPosition> DepartmentPositions => _departmentPositions.AsReadOnly();
 
     public static Result<Position> Create(
         Id<Position> id,
@@ -35,6 +36,14 @@ public class Position
         Name = name;
         Description = description;
         UpdatedAt = DateTime.UtcNow;
+
+        return this;
+    }
+
+    public Position UpdateDepartments(
+        IEnumerable<Id<Department>> departmentIds)
+    {
+        _departmentPositions = departmentIds.Select(did => new DepartmentPosition(did, Id)).ToList();
 
         return this;
     }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Position.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Domain/Position.cs
@@ -9,6 +9,8 @@ public class Position
     public Id<Position> Id { get; }
     public PositionName Name { get; private set; }
     public PositionDescription Description { get; private set; }
+
+
     public bool IsActive { get; private set; } = true;
     public DateTime CreatedAt { get; }
     public DateTime UpdatedAt { get; private set; }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/BackgroundServices/SoftDeleteCleanerBackgroundService.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/BackgroundServices/SoftDeleteCleanerBackgroundService.cs
@@ -1,121 +1,88 @@
-﻿//using Dapper;
-//using Microsoft.EntityFrameworkCore;
-//using Microsoft.Extensions.DependencyInjection;
-//using Microsoft.Extensions.Hosting;
-//using Microsoft.Extensions.Logging;
-//using Microsoft.Extensions.Options;
+﻿using Dapper;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
-//namespace DirectoryProject.DirectoryService.Infrastructure.BackgroundServices;
+namespace DirectoryProject.DirectoryService.Infrastructure.BackgroundServices;
 
-//public class SoftDeleteCleanerBackgroundService : BackgroundService
-//{
-//    private readonly IServiceScope _serviceScope;
-//    private readonly ILogger<SoftDeleteCleanerBackgroundService> _logger;
-//    private readonly IDBConnectionFactory _dBConnectionFactory;
+public class SoftDeleteCleanerBackgroundService : BackgroundService
+{
+    private readonly IDBConnectionFactory _connectionFactory;
+    private readonly ILogger<SoftDeleteCleanerBackgroundService> _logger;
 
-//    private readonly TimeSpan _checkPeriod;
-//    private readonly TimeSpan _timeToRestore;
+    private readonly TimeSpan _checkPeriod;
+    private readonly TimeSpan _timeToRestore;
 
-//    public SoftDeleteCleanerBackgroundService(
-//        IDbContextFactory<PetsWriteDBContext> dbFactory,
-//        ILogger<SoftDeleteCleanerBackgroundService> logger,
-//        [FromKeyedServices(DependencyKey.Pets)] IDBConnectionFactory dBConnectionFactory,
-//        IMessageQueue<IEnumerable<FileInfoDTO>> fileMessageQueue,
-//        IOptions<SoftDeleteCleanerOptions> options)
-//    {
-//        _dbFactory = dbFactory;
-//        _logger = logger;
-//        _dBConnectionFactory = dBConnectionFactory;
-//        _fileMessageQueue = fileMessageQueue;
-//        if (options != null)
-//        {
-//            _checkPeriod = TimeSpan.FromHours(options.Value.CheckPeriodHours);
-//            _timeToRestore = TimeSpan.FromHours(options.Value.TimeToRestoreHours);
-//        }
-//    }
+    public SoftDeleteCleanerBackgroundService(
+        IDBConnectionFactory connectionFactory,
+        ILogger<SoftDeleteCleanerBackgroundService> logger,
+        IOptions<SoftDeleteCleanerOptions> options)
+    {
+        _connectionFactory = connectionFactory;
+        _logger = logger;
 
-//    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-//    {
-//        _logger.LogInformation("SoftDeleteCleanerBackgroundService started");
+        if (options != null)
+        {
+            _checkPeriod = TimeSpan.FromHours(options.Value.CheckPeriodHours);
+            _timeToRestore = TimeSpan.FromHours(options.Value.TimeToRestoreHours);
+        }
+    }
 
-//        using PeriodicTimer timer = new(_checkPeriod);
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("SoftDeleteCleanerBackgroundService started");
 
-//        // when stop requested, waiting for timer to tick will be cancelled too
-//        while (!stoppingToken.IsCancellationRequested &&
-//            await timer.WaitForNextTickAsync(stoppingToken))
-//        {
-//            try
-//            {
-//                using var context = _dbFactory.CreateDbContext();
+        using PeriodicTimer timer = new(_checkPeriod);
 
-//                // deleting pets
-//                await _deletePets(context, stoppingToken);
+        // when stop requested, waiting for timer to tick will be cancelled too
+        while (!stoppingToken.IsCancellationRequested &&
+            await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                using var connection = _connectionFactory.Create();
 
-//                // deleting volunteers
-//                var deletedVolunteers = context.Volunteers
-//                    .Where(v => v.IsDeleted &&
-//                        DateTime.UtcNow - v.DeletionDate!.Value >= _timeToRestore);
+                var departmentDeleteResult = await connection.ExecuteAsync(new CommandDefinition(
+                    $"""
+                    DELETE FROM diretory_service.departments
+                    WHERE is_active = false AND
+                        '{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}' - updated_at >= '{_timeToRestore}'
+                    """,
+                    cancellationToken: stoppingToken));
 
-//                // this will also cascade delete related pets
-//                context.Volunteers.RemoveRange(deletedVolunteers);
-//                await context.SaveChangesAsync(stoppingToken);
+                var locationDeleteResult = await connection.ExecuteAsync(new CommandDefinition(
+                    $"""
+                    DELETE FROM diretory_service.locations
+                    WHERE is_active = false AND
+                        '{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}' - updated_at >= '{_timeToRestore}'
+                    """,
+                    cancellationToken: stoppingToken));
 
-//                _logger.LogInformation("SoftDeleteCleanerBackgroundService executed successfully");
-//            }
-//            catch (Exception ex)
-//            {
-//                _logger.LogError(ex, ex.Message);
-//            }
-//        }
+                var positionDeleteResult = await connection.ExecuteAsync(new CommandDefinition(
+                    $"""
+                    DELETE FROM diretory_service.positions
+                    WHERE is_active = false AND
+                        '{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}' - updated_at >= '{_timeToRestore}'
+                    """,
+                    cancellationToken: stoppingToken));
 
-//        _logger.LogInformation("SoftDeleteCleanerBackgroundService finished");
-//    }
+                _logger.LogInformation("SoftDeleteCleanerBackgroundService executed successfully");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, ex.Message);
+            }
+        }
 
-//    private class _petPhotosDTO
-//    {
-//        public Guid Id { get; init; }
-//        public FileVO[] Photos { get; init; } = [];
-//    }
+        _logger.LogInformation("SoftDeleteCleanerBackgroundService finished");
+    }
 
-//    private async Task _deletePets(PetsWriteDBContext context, CancellationToken stoppingToken)
-//    {
-//        using var connection = _dBConnectionFactory.Create();
-
-//        // Getting all required to delete pets. Retrieving id and file paths
-//        var petsSql = $"""
-//            SELECT id, photos
-//            FROM pets_management.Pets
-//            WHERE is_deleted AND
-//                '{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}' - deletion_date >= '{_timeToRestore}'
-//            """;
-
-//        _logger.LogInformation("Dapper pets select sql:\n{sql}", petsSql);
-//        var pets = await connection.QueryAsync<_petPhotosDTO>(petsSql);
-//        if (pets is null || pets.Any() == false)
-//            return;
-
-//        // Creating a list of ids for postgres
-//        var deletedPetIds = "('" + string.Join("', '", pets.Select(p => p.Id)) + "')";
-
-//        var petsDeleteSQL = $"""
-//            DELETE FROM pets_management.Pets
-//            WHERE id IN {deletedPetIds}
-//            """;
-//        _logger.LogInformation("Pets delete sql:\n{sql}", petsSql);
-
-//        // With raw sql it is one database call. With DDD, it will be 2 (get volunteers and update volunteers)
-//        var deleteResult = await context.Database.ExecuteSqlRawAsync(petsDeleteSQL, stoppingToken);
-
-//        // Placing an operation to delete photos of deleted pets
-//        List<FileInfoDTO> fileInfos = [];
-//        foreach (var p in pets)
-//        {
-//            var f = p.Photos.Select(photo => new FileInfoDTO(
-//                photo.PathToStorage,
-//                Constants.BucketNames.PET_PHOTOS));
-//            fileInfos.AddRange(f);
-//        }
-//        if (fileInfos.Count != 0)
-//            await _fileMessageQueue.WriteAsync(fileInfos, stoppingToken);
-//    }
-//}
+    public class SoftDeleteCleanerOptions
+    {
+        public required float CheckPeriodHours { get; set; }
+        public required float TimeToRestoreHours { get; set; }
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/BackgroundServices/SoftDeleteCleanerBackgroundService.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/BackgroundServices/SoftDeleteCleanerBackgroundService.cs
@@ -1,0 +1,121 @@
+﻿//using Dapper;
+//using Microsoft.EntityFrameworkCore;
+//using Microsoft.Extensions.DependencyInjection;
+//using Microsoft.Extensions.Hosting;
+//using Microsoft.Extensions.Logging;
+//using Microsoft.Extensions.Options;
+
+//namespace DirectoryProject.DirectoryService.Infrastructure.BackgroundServices;
+
+//public class SoftDeleteCleanerBackgroundService : BackgroundService
+//{
+//    private readonly IServiceScope _serviceScope;
+//    private readonly ILogger<SoftDeleteCleanerBackgroundService> _logger;
+//    private readonly IDBConnectionFactory _dBConnectionFactory;
+
+//    private readonly TimeSpan _checkPeriod;
+//    private readonly TimeSpan _timeToRestore;
+
+//    public SoftDeleteCleanerBackgroundService(
+//        IDbContextFactory<PetsWriteDBContext> dbFactory,
+//        ILogger<SoftDeleteCleanerBackgroundService> logger,
+//        [FromKeyedServices(DependencyKey.Pets)] IDBConnectionFactory dBConnectionFactory,
+//        IMessageQueue<IEnumerable<FileInfoDTO>> fileMessageQueue,
+//        IOptions<SoftDeleteCleanerOptions> options)
+//    {
+//        _dbFactory = dbFactory;
+//        _logger = logger;
+//        _dBConnectionFactory = dBConnectionFactory;
+//        _fileMessageQueue = fileMessageQueue;
+//        if (options != null)
+//        {
+//            _checkPeriod = TimeSpan.FromHours(options.Value.CheckPeriodHours);
+//            _timeToRestore = TimeSpan.FromHours(options.Value.TimeToRestoreHours);
+//        }
+//    }
+
+//    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+//    {
+//        _logger.LogInformation("SoftDeleteCleanerBackgroundService started");
+
+//        using PeriodicTimer timer = new(_checkPeriod);
+
+//        // when stop requested, waiting for timer to tick will be cancelled too
+//        while (!stoppingToken.IsCancellationRequested &&
+//            await timer.WaitForNextTickAsync(stoppingToken))
+//        {
+//            try
+//            {
+//                using var context = _dbFactory.CreateDbContext();
+
+//                // deleting pets
+//                await _deletePets(context, stoppingToken);
+
+//                // deleting volunteers
+//                var deletedVolunteers = context.Volunteers
+//                    .Where(v => v.IsDeleted &&
+//                        DateTime.UtcNow - v.DeletionDate!.Value >= _timeToRestore);
+
+//                // this will also cascade delete related pets
+//                context.Volunteers.RemoveRange(deletedVolunteers);
+//                await context.SaveChangesAsync(stoppingToken);
+
+//                _logger.LogInformation("SoftDeleteCleanerBackgroundService executed successfully");
+//            }
+//            catch (Exception ex)
+//            {
+//                _logger.LogError(ex, ex.Message);
+//            }
+//        }
+
+//        _logger.LogInformation("SoftDeleteCleanerBackgroundService finished");
+//    }
+
+//    private class _petPhotosDTO
+//    {
+//        public Guid Id { get; init; }
+//        public FileVO[] Photos { get; init; } = [];
+//    }
+
+//    private async Task _deletePets(PetsWriteDBContext context, CancellationToken stoppingToken)
+//    {
+//        using var connection = _dBConnectionFactory.Create();
+
+//        // Getting all required to delete pets. Retrieving id and file paths
+//        var petsSql = $"""
+//            SELECT id, photos
+//            FROM pets_management.Pets
+//            WHERE is_deleted AND
+//                '{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}' - deletion_date >= '{_timeToRestore}'
+//            """;
+
+//        _logger.LogInformation("Dapper pets select sql:\n{sql}", petsSql);
+//        var pets = await connection.QueryAsync<_petPhotosDTO>(petsSql);
+//        if (pets is null || pets.Any() == false)
+//            return;
+
+//        // Creating a list of ids for postgres
+//        var deletedPetIds = "('" + string.Join("', '", pets.Select(p => p.Id)) + "')";
+
+//        var petsDeleteSQL = $"""
+//            DELETE FROM pets_management.Pets
+//            WHERE id IN {deletedPetIds}
+//            """;
+//        _logger.LogInformation("Pets delete sql:\n{sql}", petsSql);
+
+//        // With raw sql it is one database call. With DDD, it will be 2 (get volunteers and update volunteers)
+//        var deleteResult = await context.Database.ExecuteSqlRawAsync(petsDeleteSQL, stoppingToken);
+
+//        // Placing an operation to delete photos of deleted pets
+//        List<FileInfoDTO> fileInfos = [];
+//        foreach (var p in pets)
+//        {
+//            var f = p.Photos.Select(photo => new FileInfoDTO(
+//                photo.PathToStorage,
+//                Constants.BucketNames.PET_PHOTOS));
+//            fileInfos.AddRange(f);
+//        }
+//        if (fileInfos.Count != 0)
+//            await _fileMessageQueue.WriteAsync(fileInfos, stoppingToken);
+//    }
+//}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/ApplicationWriteDBContext.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/ApplicationWriteDBContext.cs
@@ -1,6 +1,5 @@
 ﻿using DirectoryProject.DirectoryService.Domain;
 using Microsoft.EntityFrameworkCore;
-using System.Reflection;
 
 namespace DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite;
 
@@ -18,12 +17,13 @@ public class ApplicationWriteDBContext : DbContext
 
     public DbSet<Department> Departments { get; set; }
     public DbSet<DepartmentLocation> DepartmentLocations { get; set; }
+    public DbSet<DepartmentPosition> DepartmentPositions { get; set; }
     public DbSet<Location> Locations { get; set; }
     public DbSet<Position> Positions { get; set; }
 
     public async Task ApplyMigrationsAsync()
     {
-        //await Database.MigrateAsync();
+        await Database.MigrateAsync();
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Configurations/DepartmentConfiguration.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Configurations/DepartmentConfiguration.cs
@@ -72,6 +72,11 @@ public class DepartmentConfiguration : IEntityTypeConfiguration<Department>
             .HasForeignKey(dl => dl.DepartmentId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.HasMany(d => d.DepartmentPositions)
+            .WithOne(dp => dp.Department)
+            .HasForeignKey(dp => dp.DepartmentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         builder.Property(d => d.CreatedAt)
             .HasConversion(
                 src => src.Kind == DateTimeKind.Utc ? src : DateTime.SpecifyKind(src, DateTimeKind.Utc),

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Configurations/DepartmentPositionConfiguration.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Configurations/DepartmentPositionConfiguration.cs
@@ -1,0 +1,36 @@
+﻿using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite.Configurations;
+
+public class DepartmentPositionConfiguration : IEntityTypeConfiguration<DepartmentPosition>
+{
+    public void Configure(EntityTypeBuilder<DepartmentPosition> builder)
+    {
+        builder.ToTable("department_positions");
+
+        builder.HasKey(d => new { d.DepartmentId, d.PositionId });
+
+        builder.Property(d => d.DepartmentId)
+            .HasConversion(
+                id => id.Value,
+                value => Id<Department>.Create(value))
+            .HasColumnName("department_id");
+
+        builder.Property(d => d.PositionId)
+            .HasConversion(
+                id => id.Value,
+                value => Id<Position>.Create(value))
+            .HasColumnName("position_id");
+
+        builder.HasOne(dl => dl.Department)
+            .WithMany(d => d.DepartmentPositions)
+            .HasForeignKey(dl => dl.DepartmentId);
+
+        builder.HasOne(dl => dl.Position)
+            .WithMany(l => l.DepartmentPositions)
+            .HasForeignKey(dl => dl.PositionId);
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Configurations/PositionConfiguration.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Configurations/PositionConfiguration.cs
@@ -44,6 +44,11 @@ public class PositionConfiguration : IEntityTypeConfiguration<Position>
             .HasMaxLength(PositionDescription.MAX_LENGTH)
             .HasColumnName("description");
 
+        builder.HasMany(d => d.DepartmentPositions)
+            .WithOne(dp => dp.Position)
+            .HasForeignKey(dp => dp.PositionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         builder.Property(d => d.CreatedAt)
             .HasConversion(
                 src => src.Kind == DateTimeKind.Utc ? src : DateTime.SpecifyKind(src, DateTimeKind.Utc),

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Repositories/LocationRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Repositories/LocationRepository.cs
@@ -5,6 +5,7 @@ using DirectoryProject.DirectoryService.Domain.Shared;
 using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite;
 using Microsoft.EntityFrameworkCore;
+using System.Xml.Linq;
 
 namespace DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite.Repositories;
 
@@ -98,6 +99,21 @@ public class LocationRepository : ILocationRepository
 
         if (existingLocation is not null)
             return ErrorHelper.General.AlreadyExist(name.Value);
+
+        return UnitResult.Success();
+    }
+
+    public async Task<UnitResult> IsAddressUniqueAsync(
+        LocationAddress address,
+        CancellationToken cancellationToken = default)
+    {
+        var existingLocation = await _context.Locations
+            .FirstOrDefaultAsync(d => d.Address.City == address.City &&
+                d.Address.Street == address.Street &&
+                d.Address.HouseNumber == address.HouseNumber);
+
+        if (existingLocation is not null)
+            return ErrorHelper.General.AlreadyExist($"{address.City} {address.Street} {address.HouseNumber}");
 
         return UnitResult.Success();
     }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Repositories/PositionRepository.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DatabaseWrite/Repositories/PositionRepository.cs
@@ -50,8 +50,21 @@ public class PositionRepository : IPositionRepository
 
     public async Task<Result<Position>> UpdateAsync(
         Position entity,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IEnumerable<DepartmentPosition>? oldDepartmentPositions = null)
     {
+        // sync DepartmentPositions
+        if (oldDepartmentPositions is not null)
+        {
+            foreach (var item in oldDepartmentPositions)
+            {
+                var found = entity.DepartmentPositions
+                    .FirstOrDefault(d => d.PositionId == item.PositionId);
+                if (found is null)
+                    _context.DepartmentPositions.Remove(item);
+            }
+        }
+
         await _context.SaveChangesAsync(cancellationToken);
 
         return entity;

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DependencyInjection.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,8 @@ using DirectoryProject.DirectoryService.Infrastructure.BackgroundServices;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseRead;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite.Repositories;
+using DirectoryProject.DirectoryService.Infrastructure.Intefraces;
+using DirectoryProject.DirectoryService.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,8 +32,9 @@ public static class DependencyInjection
 
         services.AddScoped<IUnitOfWork, DirectoryServiceUnitOfWork>();
 
-        var configs = configuration.GetSection("SoftDeleteCleaner");
+        services.AddSingleton<IDatabaseCleanerService, DatabaseCleanerService>();
 
+        var configs = configuration.GetSection("SoftDeleteCleaner");
         services.Configure<SoftDeleteCleanerOptions>(configs);
         services.AddHostedService<SoftDeleteCleanerBackgroundService>();
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DependencyInjection.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DependencyInjection.cs
@@ -1,11 +1,13 @@
 ﻿using DirectoryProject.DirectoryService.Application.Interfaces;
 using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Infrastructure.BackgroundServices;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseRead;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using static DirectoryProject.DirectoryService.Infrastructure.BackgroundServices.SoftDeleteCleanerBackgroundService;
 
 namespace DirectoryProject.DirectoryService.Infrastructure;
 
@@ -20,13 +22,18 @@ public static class DependencyInjection
         var dbConnectionString = configuration.GetConnectionString(ApplicationWriteDBContext.DATABASE_CONFIGURATION);
         services.AddScoped(_ => new ApplicationWriteDBContext(dbConnectionString));
 
-        services.AddScoped<IDBConnectionFactory>(_ => new ReadDBConnectionFactory(dbConnectionString));
+        services.AddSingleton<IDBConnectionFactory>(_ => new ReadDBConnectionFactory(dbConnectionString));
 
         services.AddScoped<ILocationRepository, LocationRepository>();
         services.AddScoped<IDepartmentRepository, DepartmentRepository>();
         services.AddScoped<IPositionRepository, PositionRepository>();
 
         services.AddScoped<IUnitOfWork, DirectoryServiceUnitOfWork>();
+
+        var configs = configuration.GetSection("SoftDeleteCleaner");
+
+        services.Configure<SoftDeleteCleanerOptions>(configs);
+        services.AddHostedService<SoftDeleteCleanerBackgroundService>();
 
         return services;
     }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DirectoryProject.DirectoryService.Infrastructure.csproj
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DirectoryProject.DirectoryService.Infrastructure.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DirectoryProject.DirectoryService.Infrastructure.csproj
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/DirectoryProject.DirectoryService.Infrastructure.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Intefraces/IDatabaseCleanerService.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Intefraces/IDatabaseCleanerService.cs
@@ -1,0 +1,11 @@
+﻿using System.Data;
+using DirectoryProject.DirectoryService.Domain.Shared;
+
+namespace DirectoryProject.DirectoryService.Infrastructure.Intefraces;
+
+public interface IDatabaseCleanerService
+{
+    Task CleanTablesAsync(
+        TimeSpan timeToRestore,
+        CancellationToken stoppingToken = default);
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250611124301_Directory_AddedManyDepartmentsToManyPositionsRelationship.Designer.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250611124301_Directory_AddedManyDepartmentsToManyPositionsRelationship.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DirectoryProject.DirectoryService.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationWriteDBContext))]
-    partial class ApplicationDBContextModelSnapshot : ModelSnapshot
+    [Migration("20250611124301_Directory_AddedManyDepartmentsToManyPositionsRelationship")]
+    partial class Directory_AddedManyDepartmentsToManyPositionsRelationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250611124301_Directory_AddedManyDepartmentsToManyPositionsRelationship.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Migrations/20250611124301_Directory_AddedManyDepartmentsToManyPositionsRelationship.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DirectoryProject.DirectoryService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Directory_AddedManyDepartmentsToManyPositionsRelationship : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "department_positions",
+                schema: "diretory_service",
+                columns: table => new
+                {
+                    department_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    position_id = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_department_positions", x => new { x.department_id, x.position_id });
+                    table.ForeignKey(
+                        name: "fk_department_positions_departments_department_id",
+                        column: x => x.department_id,
+                        principalSchema: "diretory_service",
+                        principalTable: "departments",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_department_positions_positions_position_id",
+                        column: x => x.position_id,
+                        principalSchema: "diretory_service",
+                        principalTable: "positions",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_department_positions_position_id",
+                schema: "diretory_service",
+                table: "department_positions",
+                column: "position_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "department_positions",
+                schema: "diretory_service");
+        }
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Services/DatabaseCleanerService.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.Infrastructure/Services/DatabaseCleanerService.cs
@@ -1,0 +1,104 @@
+﻿using System.Data;
+using Dapper;
+using DirectoryProject.DirectoryService.Application.Interfaces;
+using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Infrastructure.DatabaseWrite;
+using DirectoryProject.DirectoryService.Infrastructure.Intefraces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DirectoryProject.DirectoryService.Infrastructure.Services;
+
+public class DatabaseCleanerService : IDatabaseCleanerService
+{
+    private readonly IDBConnectionFactory _connectionFactory;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<DatabaseCleanerService> _logger;
+
+    public DatabaseCleanerService(
+        IDBConnectionFactory connectionFactory,
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<DatabaseCleanerService> logger)
+    {
+        _connectionFactory = connectionFactory;
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    public async Task CleanTablesAsync(
+        TimeSpan timeToRestore,
+        CancellationToken stoppingToken = default)
+    {
+        await ExecuteChildrenUpdateAsync(stoppingToken);
+
+        string[] tableNames = {
+                "diretory_service.departments",
+                "diretory_service.positions",
+                "diretory_service.locations",
+            };
+        using var connection = _connectionFactory.Create();
+        foreach (string tableName in tableNames)
+        {
+            await ExecuteDeleteAsync(
+                connection,
+                tableName,
+                timeToRestore,
+                stoppingToken);
+        }
+    }
+
+    private async Task ExecuteChildrenUpdateAsync(
+        CancellationToken stoppingToken = default)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        using var context = scope.ServiceProvider.GetRequiredService<ApplicationWriteDBContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IDepartmentRepository>();
+
+        var deletedParents = await context.Departments
+            .IgnoreQueryFilters()
+            .Where(d => !d.IsActive)
+            .Select(d => new {
+                Path = d.Path,
+                Label = d.Path.Subpath(-1) + ".",
+                ParentId = d.ParentId,
+            })
+            .OrderByDescending(d => d.Path)
+            .ToListAsync(stoppingToken);
+
+        foreach (var parent in deletedParents)
+        {
+            var changedCount = await context.Departments
+                .Where(d => d.IsActive)
+                .Where(d => d.Path.IsDescendantOf(parent.Path))
+                .Where(d => d.Path != parent.Path)
+                .ExecuteUpdateAsync(
+                    propCall => propCall
+                    .SetProperty(
+                        d => d.Path,
+                        d => (LTree)((string)d.Path).Replace(parent.Label, string.Empty))
+                    .SetProperty(
+                        d => d.Depth,
+                        d => d.Depth - 1)
+                    .SetProperty(
+                        d => d.ParentId,
+                        d => parent.ParentId),
+                    stoppingToken);
+        }
+    }
+
+    private async Task<int> ExecuteDeleteAsync(
+        IDbConnection connection,
+        string tableName,
+        TimeSpan timeToRestore,
+        CancellationToken stoppingToken = default)
+    {
+        return await connection.ExecuteAsync(new CommandDefinition(
+            commandText: $"""
+                DELETE FROM {tableName}
+                WHERE is_active = false AND
+                    '{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}' - updated_at >= '{timeToRestore}'
+                """,
+            cancellationToken: stoppingToken));
+    }
+}

--- a/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Requests/UpdatePositionRequest.cs
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/Requests/UpdatePositionRequest.cs
@@ -4,11 +4,12 @@ namespace DirectoryProject.DirectoryService.WebAPI.Requests;
 
 public record UpdatePositionRequest(
     string Name,
-    string Description)
+    string Description,
+    IEnumerable<Guid> DepartmentIds)
 {
     public UpdatePositionCommand ToCommand(
         Guid id)
     {
-        return new UpdatePositionCommand(id, Name, Description);
+        return new UpdatePositionCommand(id, Name, Description, DepartmentIds);
     }
 }

--- a/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/appsettings.json
+++ b/src/DirectoryService/DirectoryProject.DirectoryService.WebAPI/appsettings.json
@@ -9,5 +9,9 @@
     "PostgresDB": "Server=Server;Port=Port;Database=Database;User ID=User_Id;Password=Password;Host=Host;",
     "Seq": "Seq_server_address"
   },
+  "SoftDeleteCleaner": {
+    "CheckPeriodHours": 24,
+    "TimeToRestoreHours": 720
+  },
   "AllowedHosts": "*"
 }

--- a/tests/DirectoryService.Tests/PositionHandlers/CreatePositionHandlerTests.cs
+++ b/tests/DirectoryService.Tests/PositionHandlers/CreatePositionHandlerTests.cs
@@ -1,7 +1,10 @@
 ﻿using DirectoryProject.DirectoryService.Application.PositionHandlers.CreatePosition;
 using DirectoryProject.DirectoryService.Application.Shared.DTOs;
 using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
+using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.DepartmentValueObjects;
 using DirectoryProject.DirectoryService.Domain.PositionValueObjects;
+using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Shared.Tests;
@@ -22,9 +25,17 @@ public class CreatePositionHandlerTests : DirectoryServiceBaseHandlerTests
     public async Task HandleAsync_AddingPositionWithValidCommand_ReturnSuccess()
     {
         // Arrange
+        var dep = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Test dep").Value,
+            parent: null,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Departments.Add(dep);
+
         var command = new CreatePositionCommand(
             Name: "Test Position",
-            Description: "Test description");
+            Description: "Test description",
+            DepartmentIds: [dep.Id.Value]);
 
         var ct = new CancellationTokenSource().Token;
 
@@ -42,5 +53,6 @@ public class CreatePositionHandlerTests : DirectoryServiceBaseHandlerTests
         var entity = await _context.Positions.FirstOrDefaultAsync(d => d.Name == testName);
         Assert.True(entity is not null, "Entity from database is null");
         Assert.True(entity.IsActive, "Entity is not active");
+        Assert.True(entity.DepartmentPositions.Any(), "Position is not added to Department");
     }
 }

--- a/tests/DirectoryService.Tests/PositionHandlers/UpdatePositionHandlerTests.cs
+++ b/tests/DirectoryService.Tests/PositionHandlers/UpdatePositionHandlerTests.cs
@@ -2,6 +2,7 @@
 using DirectoryProject.DirectoryService.Application.Shared.DTOs;
 using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
 using DirectoryProject.DirectoryService.Domain;
+using DirectoryProject.DirectoryService.Domain.DepartmentValueObjects;
 using DirectoryProject.DirectoryService.Domain.PositionValueObjects;
 using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
 using Microsoft.EntityFrameworkCore;
@@ -31,12 +32,28 @@ public class UpdatePositionHandlerTests : DirectoryServiceBaseHandlerTests
             createdAt: DateTime.UtcNow).Value;
         _context.Positions.Add(position);
 
+        var dep1 = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Test dep1").Value,
+            parent: null,
+            createdAt: DateTime.UtcNow).Value;
+        var dep2 = Department.Create(
+            id: Id<Department>.GenerateNew(),
+            name: DepartmentName.Create("Test dep2").Value,
+            parent: null,
+            createdAt: DateTime.UtcNow).Value;
+        _context.Departments.AddRange([dep1, dep2]);
+
+        _context.DepartmentPositions.Add(
+            new DepartmentPosition(dep1.Id, position.Id));
+
         await _context.SaveChangesAsync();
 
         var command = new UpdatePositionCommand(
             Id: position.Id.Value,
             Name: "Test Position after update",
-            Description: "Test description after update");
+            Description: "Test description after update",
+            DepartmentIds: [dep2.Id.Value]);
 
         var ct = new CancellationTokenSource().Token;
 
@@ -56,5 +73,12 @@ public class UpdatePositionHandlerTests : DirectoryServiceBaseHandlerTests
         Assert.True(
             entity.Name.Value == command.Name,
             $"Entity's name is incorrent. Expected {command.Name}, got {entity.Name}");
+
+        var expectedDepartmentPositions = await _context.DepartmentPositions
+            .Where(d => d.PositionId == entity.Id && d.DepartmentId == dep2.Id)
+            .ToListAsync();
+        Assert.True(
+            expectedDepartmentPositions.Count != 0,
+            "DepartmentPosition was not created");
     }
 }

--- a/tests/DirectoryService.Tests/PositionHandlers/UpdatePositionHandlerTests.cs
+++ b/tests/DirectoryService.Tests/PositionHandlers/UpdatePositionHandlerTests.cs
@@ -1,19 +1,12 @@
-﻿using DirectoryProject.DirectoryService.Application.LocationHandlers.UpdateLocation;
-using DirectoryProject.DirectoryService.Application.PositionHandlers.UpdatePosition;
+﻿using DirectoryProject.DirectoryService.Application.PositionHandlers.UpdatePosition;
 using DirectoryProject.DirectoryService.Application.Shared.DTOs;
 using DirectoryProject.DirectoryService.Application.Shared.Interfaces;
 using DirectoryProject.DirectoryService.Domain;
-using DirectoryProject.DirectoryService.Domain.LocationValueObjects;
 using DirectoryProject.DirectoryService.Domain.PositionValueObjects;
 using DirectoryProject.DirectoryService.Domain.Shared.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Shared.Tests;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DirectoryService.Tests.PositionHandlers;
 


### PR DESCRIPTION
Немного подогнал проект со старых заданий на новые:
1) Добавил правило валидации при создании Location, что адрес должен быть уникальным.
2) Добавил связь many-to-many между Department и Position.
3) Добавил фоновый сервис удаления неактивных сущностей (Department, Location, Position).

Ещё нужно было бы вынести в отдельные endpoint обновление локаций у Department и перенос Department в другой Department (обновление parent_id). Но оба этих действия можно сделать через существующее обновление Department, так что пока оставил так.

Кстати, в задании 13 на добавление фонового процесса, сказано про поле deleted_at, а в моделях его нет, есть updated_at т created_at
![image](https://github.com/user-attachments/assets/1bdb67d5-8acc-4ca9-9d70-d581b2bd3168)

Я у себя сделал так. Когда происходит softdelete сущности, is_active ставится false и updated_at ставится равным текущему времени. Фоновый процесс ищет все сущности с is_active = false и updated_at, равный времени на месяц назад, и удаляет их.
В фоновом процессе я делаю только удаление сущностей, без обновления путей дочерних подразделений, потому что по текущим бизнес правилам (из старых заданий), нельзя сделать softdelete подразделения, если у него есть дети.

Могу ли я оставить так, или нужно сделать в точности, как по новым заданиям?